### PR TITLE
update prometheus alerts

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -27,4 +27,4 @@ generic-service:
     AUDIT_ENABLED: "false"
 
 generic-prometheus-alerts:
-  alertSeverity: prison-education-alerts
+  alertSeverity: education-alerts-non-prod

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -26,4 +26,4 @@ generic-service:
     SYSTEM_PHASE: PREPROD
 
 generic-prometheus-alerts:
-  alertSeverity: prison-education-alerts
+  alertSeverity: education-alerts-non-prod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -20,4 +20,4 @@ generic-service:
     SYSTEM_PHASE: PROD
 
 generic-prometheus-alerts:
-  alertSeverity: prison-education-alerts
+  alertSeverity: education-alerts

--- a/package-lock.json
+++ b/package-lock.json
@@ -15409,9 +15409,10 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "version": "5.28.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+      "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },


### PR DESCRIPTION
Adjust severity alerts after setting up alert manager. Alert severity are:

- dev / preprod: `education-alerts-non-prod`
- prod: `education-alerts`

Bumps [undici](https://github.com/nodejs/undici) from 5.28.4 to 5.28.5.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/nodejs/undici/releases">undici's releases</a>.</em></p>
<blockquote>
<h2>v5.28.5</h2>
<h1>⚠️ Security Release ⚠️</h1>
<p>Fixes CVE CVE-2025-22150 <a href="https://github.com/nodejs/undici/security/advisories/GHSA-c76h-2ccp-4975">https://github.com/nodejs/undici/security/advisories/GHSA-c76h-2ccp-4975</a> (embargoed until 22-01-2025).</p>
<p><strong>Full Changelog</strong>: <a href="https://github.com/nodejs/undici/compare/v5.28.4...v5.28.5">https://github.com/nodejs/undici/compare/v5.28.4...v5.28.5</a></p>
</blockquote>
</details>