### PR TITLE
update dependencies and security patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "date-fns": "^4.1.0",
         "express": "^4.21.1",
         "express-session": "^1.18.1",
+        "formidable": "^3.5.4",
         "govuk-frontend": "^5.8.0",
         "helmet": "^7.2.0",
         "http-errors": "^2.0.0",
@@ -38,6 +39,7 @@
         "passport-oauth2": "^1.8.0",
         "redis": "^4.7.0",
         "superagent": "^10.2.0",
+        "undici": "^7.10.0",
         "url-value-parser": "^2.2.0",
         "uuid": "^10.0.0",
         "validator": "^13.12.0"
@@ -886,6 +888,18 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@azure/functions/node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@azure/identity": {
@@ -2136,6 +2150,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       }
@@ -15465,15 +15480,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
-      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.10.0.tgz",
+      "integrity": "sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "date-fns": "^4.1.0",
     "express": "^4.21.1",
     "express-session": "^1.18.1",
+    "formidable": "^3.5.4",
     "govuk-frontend": "^5.8.0",
     "helmet": "^7.2.0",
     "http-errors": "^2.0.0",
@@ -105,6 +106,7 @@
     "passport-oauth2": "^1.8.0",
     "redis": "^4.7.0",
     "superagent": "^10.2.0",
+    "undici": "^7.10.0",
     "url-value-parser": "^2.2.0",
     "uuid": "^10.0.0",
     "validator": "^13.12.0"


### PR DESCRIPTION
Update [Formidable](https://github.com/ministryofjustice/hmpps-jobs-board-ui/security/dependabot)

Updates `undici` from 5.28.5 to 7.10.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/nodejs/undici/releases">undici's releases</a>.</em></p>
<blockquote>
<h2>v7.10.0</h2>
<h1>⚠️ Security Release ⚠️</h1>
<p>Fixes CVE CVE-2025-22150 <a href="https://github.com/nodejs/undici/security/advisories/GHSA-c76h-2ccp-4975">https://github.com/nodejs/undici/security/advisories/GHSA-c76h-2ccp-4975</a> (embargoed until 22-01-2025).</p>
<h2>What's Changed</h2>
<ul>
<li>fix(<a href="https://redirect.github.com/nodejs/undici/issues/3736">#3736</a>): back-port 183f8e9 to v6.x by <a href="https://github.com/ggoodman"><code>@​ggoodman</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/3855">nodejs/undici#3855</a></li>
<li>fix(<a href="https://redirect.github.com/nodejs/undici/issues/3817">#3817</a>): send servername for SNI on TLS (<a href="https://redirect.github.com/nodejs/undici/issues/3821">#3821</a>) [backport] by <a href="https://github.com/metcoder95"><code>@​metcoder95</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/3864">nodejs/undici#3864</a></li>
<li>fix: sending formdata bodies with http2 (<a href="https://redirect.github.com/nodejs/undici/issues/3863">#3863</a>) [backport] by <a href="https://github.com/metcoder95"><code>@​metcoder95</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/3866">nodejs/undici#3866</a></li>
<li>[Backport v6.x] fix: Fixed the issue that there is no running request when http2 goaway by <a href="https://github.com/github-actions"><code>@​github-actions</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/3877">nodejs/undici#3877</a></li>
<li>types: [backport] Update return type of RetryCallback (<a href="https://redirect.github.com/nodejs/undici/issues/3851">#3851</a>) by <a href="https://github.com/metcoder95"><code>@​metcoder95</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/3876">nodejs/undici#3876</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/nodejs/undici/compare/v5.28.5...v7.10.0”>https://github.com/nodejs/undici/compare/v5.28.5...v7.10.0</a></p>
</blockquote>
</details>