### PR TITLE
ESWE-1355: suppress out-of-hours alerts

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -26,5 +26,9 @@ generic-service:
     SYSTEM_PHASE: DEV
     AUDIT_ENABLED: "false"
 
+  scheduledDowntime:
+    enabled: true
+
 generic-prometheus-alerts:
+  businessHoursOnly: true
   alertSeverity: education-alerts-non-prod

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -25,5 +25,9 @@ generic-service:
     WORK_AFTER_RELEASE_URL: "https://get-ready-for-work-preprod.hmpps.service.justice.gov.uk"
     SYSTEM_PHASE: PREPROD
 
+  scheduledDowntime:
+    enabled: true
+
 generic-prometheus-alerts:
+  businessHoursOnly: true
   alertSeverity: education-alerts-non-prod


### PR DESCRIPTION
This PR is to stop certain nginx-5xx errors that occur overnight, such as the following pinging services:

- GET /health/**
- GET /health
- GET /info 