### PR TITLE
ESWE-1466: remove not started status from the report

### DIFF
--- a/integration_tests/e2e/gsrwReports.cy.ts
+++ b/integration_tests/e2e/gsrwReports.cy.ts
@@ -134,13 +134,11 @@ context('Get someone ready to work reports', () => {
     reportsPage.supportToWorkDeclinedReasonsOver12Weeks('OTHER').contains('0')
 
     // Check work status progress
-    reportsPage.workStatusProgressWithin12Weeks('NOT_STARTED').contains('0')
     reportsPage.workStatusProgressWithin12Weeks('NO_RIGHT_TO_WORK').contains('21')
     reportsPage.workStatusProgressWithin12Weeks('SUPPORT_DECLINED').contains('16')
     reportsPage.workStatusProgressWithin12Weeks('SUPPORT_NEEDED').contains('0')
     reportsPage.workStatusProgressWithin12Weeks('READY_TO_WORK').contains('12')
 
-    reportsPage.workStatusProgressOver12Weeks('NOT_STARTED').contains('0')
     reportsPage.workStatusProgressOver12Weeks('NO_RIGHT_TO_WORK').contains('6')
     reportsPage.workStatusProgressOver12Weeks('SUPPORT_DECLINED').contains('0')
     reportsPage.workStatusProgressOver12Weeks('SUPPORT_NEEDED').contains('0')

--- a/server/routes/gsrwReporting/gsrwReportingController.ts
+++ b/server/routes/gsrwReporting/gsrwReportingController.ts
@@ -51,16 +51,6 @@ export default class GsrwReportingController {
         },
     )
 
-    const statusCountWithin12Weeks = workStatusProgress?.statusCounts?.reduce(
-      (sum: number, status: { numberOfPrisonersWithin12Weeks: number }) => sum + status.numberOfPrisonersWithin12Weeks,
-      0,
-    )
-
-    const statusCountOver12Weeks = workStatusProgress?.statusCounts?.reduce(
-      (sum: number, status: { numberOfPrisonersOver12Weeks: number }) => sum + status.numberOfPrisonersOver12Weeks,
-      0,
-    )
-
     try {
       // Persist date range from the mjma tab if necessary
       const sessionData = getSessionData(req, ['mjmaReporting', 'data']) as {
@@ -87,14 +77,6 @@ export default class GsrwReportingController {
         numberOfPrisonersOver12Weeks,
         summary,
         numberOfPrisonersStatusChange: workStatusProgress?.numberOfPrisonersStatusChange,
-        notStartedCountWithin12Weeks:
-          numberOfPrisonersWithin12Weeks - statusCountWithin12Weeks < 0
-            ? 0
-            : numberOfPrisonersWithin12Weeks - statusCountWithin12Weeks,
-        notStartedCountOver12Weeks:
-          numberOfPrisonersOver12Weeks - statusCountOver12Weeks < 0
-            ? 0
-            : numberOfPrisonersOver12Weeks - statusCountOver12Weeks,
         workStatusProgress: workStatusProgressSorted,
         supportNeededDocuments: supportNeededDocumentsSorted,
         supportToWorkDeclinedReasons: supportToWorkDeclinedReasonsSorted,

--- a/server/views/pages/gsrwReporting/partials/_gsrwWorkStatusProgress.njk
+++ b/server/views/pages/gsrwReporting/partials/_gsrwWorkStatusProgress.njk
@@ -27,17 +27,7 @@
           More than 12 weeks from release
         </dd>
       </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Not started
-        </dt>
-        <dd class="govuk-summary-list__value" data-qa="workStatusProgress_NOT_STARTED_numberOfPrisonersWithin12Weeks">
-          {{ notStartedCountWithin12Weeks }}
-        </dd>
-        <dd class="govuk-summary-list__value" data-qa="workStatusProgress_NOT_STARTED_numberOfPrisonersOver12Weeks">
-          {{ notStartedCountOver12Weeks }}
-        </dd>
-      </div>
+
       {% for entry in workStatusProgress %}
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">


### PR DESCRIPTION
Not started’ is not a status as such, but an indicator that there isn’t an assessment present. If it’s not possible to calculate how many assessments have not been started in the date range in the past on eligible records then this needs to be removed for consistency and clarity.