### PR TITLE
ESWE-1887: Skip Cypress installation at docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN test -n "$GIT_BRANCH" || (echo "GIT_BRANCH not set" && false)
 WORKDIR /app
 
 COPY package*.json .allowed-scripts.mjs .npmrc ./
-RUN NPM_CONFIG_AUDIT=false NPM_CONFIG_FUND=false npm run setup
+RUN CYPRESS_INSTALL_BINARY=0 NPM_CONFIG_AUDIT=false NPM_CONFIG_FUND=false npm run setup
 ENV NODE_ENV='production'
 
 COPY . .


### PR DESCRIPTION
add back `CYPRESS_INSTALL_BINARY=0`