### PR TITLE
ESWE-1927: Add Application Insights browser client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.1047.0",
+        "@microsoft/applicationinsights-clickanalytics-js": "3.4.1",
+        "@microsoft/applicationinsights-web": "3.4.1",
         "@ministryofjustice/frontend": "9.0.0",
         "@ministryofjustice/hmpps-connect-dps-components": "5.4.0",
         "agentkeepalive": "^4.5.0",
@@ -2599,11 +2601,159 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@microsoft/applicationinsights-analytics-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-3.4.1.tgz",
+      "integrity": "sha512-zdxZzu50/gsE2JWrzeviHloFZu9r5/x2+OLD0TIYHhvrod321AKkStmKlDoep1JAsSephjxBfwTjciKiFXXyGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-cfgsync-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-cfgsync-js/-/applicationinsights-cfgsync-js-3.4.1.tgz",
+      "integrity": "sha512-ifNgSIisKM/rZoLdpzS6sIQqBBRNXXAhiazZizwoP2MLdK93Z8JcPNi6eXkKPhW0Fi3SuoUivCaM7GgAMgVEFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-channel-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.4.1.tgz",
+      "integrity": "sha512-QS1k6iwVwR1MznGAB1H0F9raqpevbFNbadLS5O1419pz9OEWBfF9wRQLnENCyo8QS9Q0IdiqnGAON/D8IywpWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-clickanalytics-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-clickanalytics-js/-/applicationinsights-clickanalytics-js-3.4.1.tgz",
+      "integrity": "sha512-pReWe5CWjHYImqSuoNtefiMVlYV3ggKmahsQgenNXx3hlXDpRxXV4oosdQTidsfJhXvX1t8mZMQD2ouwofWn/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-properties-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-core-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
+      "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-dependencies-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-3.4.1.tgz",
+      "integrity": "sha512-cnjVVTxSeavmwCoOwXi/ZQuCcjo7SnYYRWyS+GsMCrTRTItVHZlVj6NHgmFEQZWNybrM+U1RgwZE2wXn1/Liyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-properties-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-3.4.1.tgz",
+      "integrity": "sha512-s2cUuknjazaoCbh9i6ljymeZqeQqpyAE8v2ZUxCkAwRuxbonAvZWQtEr4QQmEHWJIdbWgn0Ge+OOlMtMkh+Ixg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-shims": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+      "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-web": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-3.4.1.tgz",
+      "integrity": "sha512-gdYLIYkP11D+V71nNCupYsmWE8LAL9EpIR2Q7+B3n6dpck7tgaYMXFN3S5ZrOh3yxLAwt7GVXZoDcN2mGkagxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-analytics-js": "3.4.1",
+        "@microsoft/applicationinsights-cfgsync-js": "3.4.1",
+        "@microsoft/applicationinsights-channel-js": "3.4.1",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-dependencies-js": "3.4.1",
+        "@microsoft/applicationinsights-properties-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
     "node_modules/@microsoft/applicationinsights-web-snippet": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.2.3.tgz",
       "integrity": "sha512-59ex4x1/PabGQIg+o0GKG5olqAJYBvMOiXec/9HCD3hK2y36YMWT0ivq5mequvtS5+21kco3SOnMB6QyScLPIA==",
       "license": "MIT"
+    },
+    "node_modules/@microsoft/dynamicproto-js": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.5.tgz",
+      "integrity": "sha512-V+Zr7PDKIEaItVwF/OyWQlKeugNRYg7KJJ+RhEIL2FMW6NlG8FN2l4XA9Z42hNtsjwJFlcUiF38pmM/AaXsF7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
+      }
     },
     "node_modules/@ministryofjustice/frontend": {
       "version": "9.0.0",
@@ -2682,6 +2832,41 @@
       "engines": {
         "node": "20 || 22 || 24"
       }
+    },
+    "node_modules/@nevware21/ts-async": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.6.1.tgz",
+      "integrity": "sha512-W2kFiT5oPuxTrB3NrxUId/U+1AuAhIaiDQkLC4HcxkjNc+85GfELYdPQXnsDWDG8yji24F5qk6QpBDxZX3/0+g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nevware21"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/nevware21"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.15.0 < 2.x"
+      }
+    },
+    "node_modules/@nevware21/ts-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.15.0.tgz",
+      "integrity": "sha512-+bUMKIiKAgoW5uNEb5xxzBzdwdLS9SKRcOy8SxLE+KqSlIdUYV5O9nxJVq1RUYcO2DtL5DlrK1GbgcVEHv6GVA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nevware21"
+        },
+        {
+          "type": "other",
+          "url": "https://buymeacoffee.com/nevware21"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.1047.0",
+    "@microsoft/applicationinsights-clickanalytics-js": "3.4.1",
+    "@microsoft/applicationinsights-web": "3.4.1",
     "@ministryofjustice/frontend": "9.0.0",
     "@ministryofjustice/hmpps-connect-dps-components": "5.4.0",
     "agentkeepalive": "^4.5.0",

--- a/server/config.ts
+++ b/server/config.ts
@@ -142,6 +142,7 @@ export default {
   sqs: {
     audit: auditConfig(),
   },
+  appInsightsConnectionString: get('APPLICATIONINSIGHTS_CONNECTION_STRING', ''),
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   environmentName: get('ENVIRONMENT_NAME', ''),
   dpsHomeUrl: get('DPS_URL', 'http://localhost:3001/', requiredInProduction),

--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -28,6 +28,8 @@ export default function setUpStaticResources(): Router {
     '/node_modules/govuk-frontend/dist',
     '/node_modules/@ministryofjustice/frontend/moj/assets',
     '/node_modules/@ministryofjustice/frontend',
+    '/node_modules/@microsoft/applicationinsights-web/dist/es5',
+    '/node_modules/@microsoft/applicationinsights-clickanalytics-js/dist/es5',
   ).forEach(dir => {
     router.use('/assets', express.static(path.join(process.cwd(), dir), { setHeaders: excludeHiddenFiles }))
   })

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -3,7 +3,7 @@ import express, { Router, Request, Response, NextFunction } from 'express'
 import helmet from 'helmet'
 import config from '../config'
 
-const azureDomains = ['https://northeurope-0.in.applicationinsights.azure.com', '*.monitor.azure.com']
+const azureDomains = ['https://northeurope-0.in.applicationinsights.azure.com', 'https://js.monitor.azure.com']
 
 export default function setUpWebSecurity(): Router {
   const router = express.Router()
@@ -33,7 +33,6 @@ export default function setUpWebSecurity(): Router {
           scriptSrc: [
             "'self'",
             config.apis.frontendComponents.url,
-            ...azureDomains,
             (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`,
           ],
           styleSrc: [

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -3,6 +3,8 @@ import express, { Router, Request, Response, NextFunction } from 'express'
 import helmet from 'helmet'
 import config from '../config'
 
+const azureDomains = ['https://northeurope-0.in.applicationinsights.azure.com', '*.monitor.azure.com']
+
 export default function setUpWebSecurity(): Router {
   const router = express.Router()
 
@@ -31,6 +33,7 @@ export default function setUpWebSecurity(): Router {
           scriptSrc: [
             "'self'",
             config.apis.frontendComponents.url,
+            ...azureDomains,
             (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`,
           ],
           styleSrc: [
@@ -38,6 +41,7 @@ export default function setUpWebSecurity(): Router {
             config.apis.frontendComponents.url,
             (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`,
           ],
+          connectSrc: ["'self'", ...azureDomains],
           fontSrc: ["'self'", config.apis.frontendComponents.url],
           formAction: [`'self' ${config.apis.hmppsAuth.externalUrl}`],
           objectSrc: ["'none'"], // Disallow <object> or <embed> tags

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -15,6 +15,8 @@ export default function nunjucksSetup(app: express.Express): void {
   app.locals.asset_path = '/assets/'
   app.locals.dpsHomeUrl = config.dpsHomeUrl
   app.locals.applicationName = 'Hmpps Jobs Board Reporting Ui'
+  app.locals.appInsightsConnectionString = config.appInsightsConnectionString
+  app.locals.buildNumber = config.buildNumber
   app.locals.environmentName = config.environmentName
   app.locals.environmentNameColour = config.environmentName === 'PRE-PRODUCTION' ? 'govuk-tag--green' : ''
   let assetManifest: Record<string, string> = {}

--- a/server/views/partials/appInsightsWebTracking.njk
+++ b/server/views/partials/appInsightsWebTracking.njk
@@ -1,0 +1,32 @@
+{% if appInsightsConnectionString %}
+  <script type="text/javascript" src="/assets/applicationinsights-web.min.js" nonce="{{ cspNonce }}"></script>
+  <script type="text/javascript" src="/assets/applicationinsights-clickanalytics-js.min.js" nonce="{{ cspNonce }}"></script>
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+    const clickPluginInstance = new Microsoft.ApplicationInsights.ClickAnalyticsPlugin();
+    const clickPluginConfig = {
+      autoCapture: true,
+      dataTags: {
+        useDefaultContentNameOrId: true
+      }
+    };
+    const snippet = {
+      config: {
+        connectionString: "{{ appInsightsConnectionString }}",
+        extensions: [clickPluginInstance],
+        extensionConfig: {
+          [clickPluginInstance.identifier]: clickPluginConfig
+        },
+        autoTrackPageVisitTime: true
+      }
+    };
+    const init = new Microsoft.ApplicationInsights.ApplicationInsights(snippet);
+    const appInsights = init.loadAppInsights();
+
+    appInsights.addTelemetryInitializer(function (envelope) {
+      envelope.tags["ai.cloud.role"] = "hmpps-jobs-board-reporting-ui";
+      envelope.tags["ai.application.ver"] = "{{ buildNumber }}";
+    });
+
+    appInsights.trackPageView();
+  </script>
+{% endif %}

--- a/server/views/partials/appInsightsWebTracking.njk
+++ b/server/views/partials/appInsightsWebTracking.njk
@@ -11,7 +11,7 @@
     };
     const snippet = {
       config: {
-        connectionString: "{{ appInsightsConnectionString }}",
+        connectionString: {{ appInsightsConnectionString | dump | safe }},
         extensions: [clickPluginInstance],
         extensionConfig: {
           [clickPluginInstance.identifier]: clickPluginConfig
@@ -24,7 +24,7 @@
 
     appInsights.addTelemetryInitializer(function (envelope) {
       envelope.tags["ai.cloud.role"] = "hmpps-jobs-board-reporting-ui";
-      envelope.tags["ai.application.ver"] = "{{ buildNumber }}";
+      envelope.tags["ai.application.ver"] = {{ buildNumber | dump | safe }};
     });
 
     appInsights.trackPageView();

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -1,6 +1,7 @@
 {% extends "govuk/template.njk" %}
 
 {% block head %}
+  {% include "partials/appInsightsWebTracking.njk" %}
   <link href="{{ '/assets/css/app.css' | assetMap }}" rel="stylesheet"/>
 
   {% for css in feComponents.cssIncludes %}


### PR DESCRIPTION
Initialises the Azure Application Insights JavaScript SDK in the global layout with page view tracking, click analytics, AJAX/fetch dependency tracking, JS exception tracking, and browser performance metrics.
- Serve SDK and click analytics plugin from node_modules as static assets
- Expose connection string from APPLICATIONINSIGHTS_CONNECTION_STRING to Nunjucks via app.locals (no-op when env var is absent)
- Extend CSP script-src and add connect-src to allow Azure ingestion endpoints