### PR TITLE
ESWE-1927: Fix AppInsights not tracking requests

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,5 +1,5 @@
 // Require app insights before anything else to allow for instrumentation of bunyan and express
-import 'applicationinsights'
+import './server/utils/azureAppInsights'
 
 import app from './server/index'
 import logger from './logger'

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -1,13 +1,8 @@
 /* eslint-disable import/first */
-/*
- * Do appinsights first as it does some magic instrumentation work, i.e. it affects other 'require's
- * In particular, applicationinsights automatically collects bunyan logs
- */
-import { initialiseAppInsights, buildAppInsightsClient } from '../utils/azureAppInsights'
+import { buildAppInsightsClient } from '../utils/azureAppInsights'
 import applicationInfoSupplier from '../applicationInfo'
 
 const applicationInfo = applicationInfoSupplier()
-initialiseAppInsights()
 buildAppInsightsClient(applicationInfo)
 
 import HmppsAuthClient from './hmppsAuthClient'

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -8,7 +8,7 @@ import {
 import { RequestHandler } from 'express'
 import type { ApplicationInfo } from '../applicationInfo'
 
-export function initialiseAppInsights(): void {
+function initialiseAppInsights(): void {
   if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
     // eslint-disable-next-line no-console
     console.log('Enabling azure application insights')
@@ -16,6 +16,8 @@ export function initialiseAppInsights(): void {
     setup().setDistributedTracingMode(DistributedTracingModes.AI_AND_W3C).start()
   }
 }
+
+initialiseAppInsights()
 
 export function buildAppInsightsClient(
   { applicationName, buildNumber }: ApplicationInfo,


### PR DESCRIPTION
Fix: move initialisation to module scope in `azureAppInsights.ts`, called via a side-effect import in `server.ts` before any other modules load.