### PR TITLE
Fix Snyk scan report errors - undici

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "passport-oauth2": "^1.8.0",
         "redis": "^4.7.0",
         "superagent": "^10.2.3",
-        "undici": "^7.11.0",
+        "undici": "^7.29.0",
         "url-value-parser": "^2.2.0",
         "validator": "^13.15.23"
       },
@@ -13568,9 +13568,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17065,9 +17065,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "passport-oauth2": "^1.8.0",
     "redis": "^4.7.0",
     "superagent": "^10.2.3",
-    "undici": "^7.11.0",
+    "undici": "^7.29.0",
     "url-value-parser": "^2.2.0",
     "validator": "^13.15.23"
   },
@@ -205,7 +205,7 @@
       "js-yaml": "4.3.0"
     },
     "node-gyp": {
-      "undici": "6.27.0"
+      "undici": "6.28.0"
     },
     "@opentelemetry/core": "^2.8.0"
   }


### PR DESCRIPTION
Dependency updates:

* Updated the main `undici` dependency version from `^7.11.0` to `^7.29.0` in `package.json`.
* Updated the `undici` version in the `node-gyp` section from `6.27.0` to `6.28.0` in `package.json`.